### PR TITLE
Restructure pull-request to avoid breaking the API

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,16 +16,11 @@ import (
 const dnsTimeout time.Duration = 2 * time.Second
 const tcpIdleTimeout time.Duration = 8 * time.Second
 
-type TsigAlgorithm struct {
-	Generate tsigAlgorithmGenerate
-	Verify   tsigAlgorithmVerify
-}
-
 // A Conn represents a connection to a DNS server.
 type Conn struct {
-	net.Conn                              // a net.Conn holding the connection
-	UDPSize        uint16                 // minimum receive buffer for UDP messages
-	TsigSecret     map[string]interface{} // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	net.Conn                         // a net.Conn holding the connection
+	UDPSize        uint16            // minimum receive buffer for UDP messages
+	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
 	TsigAlgorithm  map[string]*TsigAlgorithm
 	rtt            time.Duration
 	t              time.Time
@@ -42,10 +37,10 @@ type Client struct {
 	// WriteTimeout when non-zero. Can be overridden with net.Dialer.Timeout (see Client.ExchangeWithDialer and
 	// Client.Dialer) or context.Context.Deadline (see the deprecated ExchangeContext)
 	Timeout        time.Duration
-	DialTimeout    time.Duration          // net.DialTimeout, defaults to 2 seconds, or net.Dialer.Timeout if expiring earlier - overridden by Timeout when that value is non-zero
-	ReadTimeout    time.Duration          // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
-	WriteTimeout   time.Duration          // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
-	TsigSecret     map[string]interface{} // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	DialTimeout    time.Duration     // net.DialTimeout, defaults to 2 seconds, or net.Dialer.Timeout if expiring earlier - overridden by Timeout when that value is non-zero
+	ReadTimeout    time.Duration     // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
+	WriteTimeout   time.Duration     // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
+	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
 	TsigAlgorithm  map[string]*TsigAlgorithm
 	SingleInflight bool // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
 	group          singleflight
@@ -223,14 +218,14 @@ func (co *Conn) ReadMsg() (*Msg, error) {
 				if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 					return m, ErrSecret
 				}
-				err = TsigVerifyByAlgorithm(p, a.Verify, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
+				err = TsigVerifyByAlgorithm(p, a.Verify, t.Hdr.Name, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
 			}
 		} else {
 			if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 				return m, ErrSecret
 			}
 			// Need to work on the original message p, as that was used to calculate the tsig.
-			err = TsigVerify(p, co.TsigSecret[t.Hdr.Name].(string), co.tsigRequestMAC, false)
+			err = TsigVerify(p, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
 		}
 	}
 	return m, err
@@ -371,13 +366,13 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 				if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 					return ErrSecret
 				}
-				out, mac, err = TsigGenerateByAlgorithm(m, a.Generate, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
+				out, mac, err = TsigGenerateByAlgorithm(m, a.Generate, t.Hdr.Name, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
 			}
 		} else {
 			if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 				return ErrSecret
 			}
-			out, mac, err = TsigGenerate(m, co.TsigSecret[t.Hdr.Name].(string), co.tsigRequestMAC, false)
+			out, mac, err = TsigGenerate(m, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
 		}
 		// Set for the next read, although only used in zone transfers
 		co.tsigRequestMAC = mac

--- a/tsig.go
+++ b/tsig.go
@@ -91,7 +91,7 @@ type timerWireFmt struct {
 	Fudge      uint16
 }
 
-func tsigGenerateHmac(msg []byte, algorithm string, name, secret string) ([]byte, error) {
+func tsigGenerateHmac(msg []byte, algorithm, name, secret string) ([]byte, error) {
 	rawsecret, err := fromBase64([]byte(secret))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit removes the interface{} 'meta' argument, which required
breaking the signature of TsigSecret, and instead passes the name
directly to the callback. If there is a need to use a non-string secret,
this can be looked up from within a closure using the name as a lookup
key.

This change still permits all the same use-cases as it's parent.

This is related to the discussion in miekg/dns#626.